### PR TITLE
fix: fully qualify hashmap

### DIFF
--- a/doc_consts_derive/src/lib.rs
+++ b/doc_consts_derive/src/lib.rs
@@ -36,12 +36,11 @@ pub fn doc_consts(input: TokenStream) -> TokenStream {
             {fields}
         }}
 
-        use std::collections::HashMap;
         impl doc_consts::DocConsts for {ident}{{
-            fn get_docs_map() -> HashMap<&'static str,&'static str> {{
-                HashMap::from([
+            fn get_docs_map() -> std::collections::HashMap<&'static str,&'static str> {{
+                std::collections::HashMap::from([
                     {map_items}
-                ])                
+                ])
             }}
         }}
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -11,10 +11,17 @@ mod tests {
         field2: (),
     }
 
+    #[derive(DocConsts)]
+    struct Test2 {
+        /// a third doc comment
+        field: (),
+    }
+
     #[test]
     fn it_works() {
         assert_eq!("doc comment\n    with indentation", Test::get_docs().field);
         assert_eq!("another doc comment", Test::get_docs().field2);
+        assert_eq!("a third doc comment", Test2::get_docs().field);
     }
 
     fn trait_test(_: impl DocConsts) {}


### PR DESCRIPTION
this resolves the following issue that occurs if multiple DocConsts are used in the same place:

```
error[E0252]: the name `HashMap` is defined multiple times
  --> src/lib.rs:14:14
   |
5  |     #[derive(DocConsts)]
   |              --------- previous import of the type `HashMap` here
...
14 |     #[derive(DocConsts)]
   |              ^^^^^^^^^ `HashMap` reimported here
   |
   = note: `HashMap` must be defined only once in the type namespace of this module
   = note: this error originates in the derive macro `DocConsts` (in Nightly builds, run with -Z macro-backtrace for more info)
```